### PR TITLE
ci: add Dependabot for uv and GitHub Actions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,28 @@
+# Dependabot configuration
+# Docs: https://docs.github.com/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file
+version: 2
+updates:
+  # Python tooling deps (pyproject.toml + uv.lock)
+  - package-ecosystem: "uv"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 5
+    commit-message:
+      prefix: "deps"
+    groups:
+      python-dependencies:
+        patterns:
+          - "*"
+
+  # GitHub Actions used in .github/workflows/
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    commit-message:
+      prefix: "ci"
+    groups:
+      github-actions:
+        patterns:
+          - "*"


### PR DESCRIPTION
## Summary

Adds Dependabot version updates so dependency bumps come in as automated PRs.

| Ecosystem | Watches | Schedule | Commit prefix |
|-----------|---------|----------|---------------|
| `uv` | `pyproject.toml` + `uv.lock` | weekly | `deps:` |
| `github-actions` | actions in `.github/workflows/` | weekly | `ci:` |

## Notes
- Uses the native **`uv`** ecosystem so `uv.lock` is updated correctly (not just `pyproject.toml`).
- Updates are **grouped per ecosystem** to keep PR noise low and run CI once per group.
- `open-pull-requests-limit: 5` on the Python stream as a safety cap.

Dependabot auto-activates once this is on the default branch — no settings toggle needed.