### PR TITLE
ci(atomic): fix engine-install rate-limit (403) + add install retries

### DIFF
--- a/.github/workflows/atomic.yml
+++ b/.github/workflows/atomic.yml
@@ -54,18 +54,51 @@ jobs:
         run: python tests/atomic/run_atomics.py --check-coverage --strict-essential
         shell: bash
 
+      # Resolve "latest" ourselves with an authenticated API call (GITHUB_TOKEN,
+      # ~1000 req/h/repo) instead of letting the install script make an
+      # unauthenticated one (60 req/h shared across all runner IPs -> 403).
+      # Passing --version then makes the install script skip the API call entirely.
+      - name: Resolve latest rustinel version
+        id: engine
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          tag="$(gh release view --repo Karib0u/rustinel --json tagName --jq '.tagName')"
+          echo "version=${tag#v}" >> "$GITHUB_OUTPUT"
+          echo "Resolved rustinel engine version: ${tag#v}"
+        shell: bash
+
       - name: Install rustinel engine (Linux)
         if: matrix.platform == 'linux'
         run: |
-          curl -fsSL https://raw.githubusercontent.com/Karib0u/rustinel/main/scripts/install/install.sh \
-            | sh -s -- --dir "$GITHUB_WORKSPACE/tests/atomic/.engine"
+          for attempt in 1 2 3; do
+            if curl -fsSL https://raw.githubusercontent.com/Karib0u/rustinel/main/scripts/install/install.sh \
+                | sh -s -- --dir "$GITHUB_WORKSPACE/tests/atomic/.engine" --version "${{ steps.engine.outputs.version }}" --force; then
+              exit 0
+            fi
+            echo "engine install attempt $attempt failed; retrying in $((attempt * 10))s" >&2
+            sleep "$((attempt * 10))"
+          done
+          echo "engine install failed after 3 attempts" >&2
+          exit 1
         shell: bash
 
       - name: Install rustinel engine (Windows)
         if: matrix.platform == 'windows'
         run: |
           Invoke-WebRequest https://raw.githubusercontent.com/Karib0u/rustinel/main/scripts/install/install.ps1 -OutFile install.ps1
-          powershell -ExecutionPolicy Bypass -File .\install.ps1 -InstallDir "$env:GITHUB_WORKSPACE\tests\atomic\.engine"
+          $ok = $false
+          for ($attempt = 1; $attempt -le 3; $attempt++) {
+            try {
+              powershell -ExecutionPolicy Bypass -File .\install.ps1 -InstallDir "$env:GITHUB_WORKSPACE\tests\atomic\.engine" -Version "${{ steps.engine.outputs.version }}" -Force
+              if ($LASTEXITCODE -eq 0) { $ok = $true; break }
+            } catch {
+              Write-Host "attempt $attempt threw: $_"
+            }
+            Write-Host "engine install attempt $attempt failed; retrying in $($attempt * 10)s"
+            Start-Sleep -Seconds ($attempt * 10)
+          }
+          if (-not $ok) { exit 1 }
         shell: pwsh
 
       - name: Exclude workspace from Defender (Windows, for EICAR)


### PR DESCRIPTION
## Problem

Every atomic failure today traced to the engine-install step, not the rules or tests. The upstream install scripts (`install.sh` / `install.ps1`) resolve `version=latest` via an **unauthenticated** call to `https://api.github.com/repos/Karib0u/rustinel/releases/latest`.

Unauthenticated GitHub API calls are capped at **60/hour per IP**, and GitHub-hosted runners share egress IPs across all customers — so that budget is routinely exhausted. The failures it produced today:

- **Linux:** `curl: (22) ... 403` → *"Could not resolve latest release"*
- **Windows:** the same throttled call returned an empty tag, yielding a bogus download URL → *"No published release asset found ... rustinel-1.1.1-x86_64-pc-windows-msvc.zip"* (the asset exists; the lookup failed)
- A separate transient **504** on the release CDN also failed the job outright, since there was no retry.

Because the limit is shared and time-windowed, it presents as a coin-flip: green on a PR re-run, red on the next push to `main`.

## Fix

1. **Resolve `latest` ourselves, authenticated.** A new step uses `gh release view --repo Karib0u/rustinel` with `GH_TOKEN: ${{ github.token }}` (~1000 req/h/repo, not the shared 60/h), then passes the tag via `--version`/`-Version`. With an explicit version, the install scripts **skip their own API call entirely** — so there are zero unauthenticated calls. Still tracks latest; no manual version bumps.
2. **Retry both installs 3× with backoff** (+ `--force`/`-Force` for idempotent re-attempts) to ride out transient CDN errors like the 504.

No change to the rules, tests, or the action-version bumps from #7.

## Notes
- `gh` is preinstalled on both ubuntu and windows runners; the resolve step uses `shell: bash` (Git Bash on Windows) and runs once per matrix leg.
- Reading a public repo's release metadata needs no extra scope beyond the existing `permissions: contents: read`.