### PR TITLE
ci(atomic): drop nightly schedule trigger

### DIFF
--- a/.github/workflows/atomic.yml
+++ b/.github/workflows/atomic.yml
@@ -17,8 +17,6 @@ on:
   pull_request:
   push:
     branches: [main]
-  schedule:
-    - cron: "0 6 * * *"        # nightly 06:00 UTC
 
 permissions:
   contents: read


### PR DESCRIPTION
## What

Removes the `schedule` (nightly `0 6 * * *`) trigger from the `atomic` workflow. The remaining triggers — `pull_request`, `push` to `main`, and `workflow_dispatch` — are unchanged.

## Why

The atomic workflow isn't a unit test of repo commits — it spins up real Windows + Linux runners, installs the **latest published rustinel engine release**, detonates an atomic action per rule, and asserts an alert fired. The nightly cron existed as a regression canary against drift that happens even when the repo is idle (a new engine release changing match behavior; install-script / runner-image / Defender changes).

Pre-first-release, we control both the rules and the engine, so that canary value isn't realized yet. Meanwhile the daily two-OS run:

- burns CI minutes on days nothing changed, and
- can fail on upstream engine releases or flaky install-script fetches, producing noise with no commit to correlate against.

PR/push already cover every rule change, and `workflow_dispatch` covers ad-hoc runs.

## Follow-up

Re-introduce a schedule (likely **weekly**, e.g. `0 6 * * 1`) once we're post-release and the engine ships versions independently of the rules — that's when "did a new engine break us overnight?" becomes worth automating.