### PR TITLE
docs: audit cleanup — stray tags, broken links, config dedup

### DIFF
--- a/docs/authoring.md
+++ b/docs/authoring.md
@@ -193,4 +193,3 @@ uv run python tools/build_packs.py  # should produce dist/ cleanly
 
 For the CI checks that run on every push, see
 [Detection as Code](detection-as-code.md).
-</content>

--- a/docs/index.md
+++ b/docs/index.md
@@ -49,4 +49,3 @@ uv run ruff check tools         # lint
 uv run ruff format tools        # format
 uv run ty check                 # type-check
 ```
-</content>

--- a/docs/packs.md
+++ b/docs/packs.md
@@ -124,9 +124,9 @@ positives may occur — especially from package installs — so tune before rely
 > macOS packs are **experimental and post-v1** — not yet production-ready — so both are
 > `default: false`. Content is built on Apple's EndpointSecurity sensor (process, file, network,
 > DNS). The process exec event carries full `CommandLine` (argv) natively, but **code-signing
-> fields are not yet exposed**, which caps how low the false-positive rate can go; see the
-> [code-signing telemetry proposal](proposals/macos-codesigning-telemetry.md) for the engine
-> enhancement that would let several Advanced rules graduate to Essential.
+> fields are not yet exposed**, which caps how low the false-positive rate can go. Exposing
+> code-signing telemetry is a planned engine enhancement that would let several Advanced rules
+> graduate to Essential.
 
 ### macOS Essential
 
@@ -179,4 +179,3 @@ After a build, `dist/index.json` carries the resolved, machine-readable version 
 per-pack `rule_count`, `ioc_count`, `attack_coverage`, `telemetry_requirements`, the list of
 resolved `rules`, a `sha256`, and the drop-in `engine` paths. See
 [the build output](repository.md#indexjson-shape).
-</content>

--- a/docs/repository.md
+++ b/docs/repository.md
@@ -146,4 +146,3 @@ automatically:
 - [Pack catalog & rule inventory](packs.md)
 - [What Rustinel supports](rustinel-support.md) — before authoring anything
 - [Using a pack with Rustinel](usage.md)
-</content>

--- a/docs/rustinel-support.md
+++ b/docs/rustinel-support.md
@@ -108,8 +108,8 @@ you write portable Sigma.
 > **macOS: command-line and parent fields are native, except `ParentCommandLine`.** ESF exec events
 > carry `CommandLine` (argv), `ParentImage`, `ParentProcessId` and `CurrentDirectory` directly, so
 > they are reliably populated (no `/proc` race). However **`ParentCommandLine` is not provided** on
-> macOS — don't depend on it in macOS rules. Code-signing fields are not exposed yet either; see the
-> [code-signing telemetry proposal](proposals/macos-codesigning-telemetry.md).
+> macOS — don't depend on it in macOS rules. Code-signing fields are not exposed yet either, a
+> known gap planned for a future engine enhancement.
 
 ### `file_event` (and `file_create` / `file_delete` / `file_change` / `file_rename`)
 
@@ -294,4 +294,3 @@ safeguards and a minimum-severity gate, all off/conservative by default. See
 - [ ] Every `|modifier` used is in the [modifier table](#field-modifiers-fieldmodifier).
 - [ ] `rustinel.telemetry` lists the right channel(s) (`file_scan` for YARA/hash IOC).
 - [ ] `uv run python tools/validate.py` passes.
-</content>

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -67,8 +67,11 @@ Rebuild a pack into the same location and the engine picks it up without a resta
 
 ## `config.toml` reference (rule-relevant sections)
 
-Defaults shown are the engine defaults. Only the paths above are required to load a pack; the rest
-are tuning knobs.
+This is the pack-installer's subset of the engine config — only the keys that affect loading and
+matching detection content. The **full, canonical reference** (logging, alerts, network
+aggregation, every default) lives in the engine docs:
+[Configuration](https://docs.rustinel.io/configuration/). Defaults shown here are the engine
+defaults; only the paths above are required to load a pack, the rest are tuning knobs.
 
 ### `[scanner]` — Sigma & YARA
 
@@ -112,6 +115,7 @@ are tuning knobs.
 | --- | ------- | ------- |
 | `paths` | OS-shipped dirs (e.g. `C:\Windows\`, `/usr/bin/`, `/System/`) | Trusted prefixes applied to YARA, hash IOC, and response. Per-module allowlists fall back to this. |
 
+<a id="active-response"></a>
 ### `[response]` — optional active response
 
 | Key | Default | Meaning |
@@ -141,4 +145,3 @@ are tuning knobs.
 
 For the engine itself (install, run as a service/daemon, telemetry setup), see the
 [Rustinel documentation](https://docs.rustinel.io/).
-</content>


### PR DESCRIPTION
Cleanup pass on the rules-repo docs for accuracy and tidiness.

## What's in here
- **Stray markup** — removed the literal trailing `</content>` tag that was rendering as visible text at the bottom of 6 pages: usage, packs, authoring, repository, rustinel-support, index.
- **Broken links** — the two references to `proposals/macos-codesigning-telemetry.md` pointed at a file that doesn't exist; reworded them to describe the planned engine enhancement inline. Added an explicit `#active-response` anchor in `usage.md` so the link from `rustinel-support.md` resolves (the heading anchor had drifted).
- **Config de-duplication** — `usage.md`'s `config.toml` table now explicitly frames itself as the pack-installer subset and links to the canonical engine Configuration reference, reducing drift between the two repos.

## Scope
Docs only — no rules, tooling, or schema changes. Kept the per-category field/modifier tables in `rustinel-support.md` (they're the rule-author contract and can't be shared cross-repo; the page already defers to the engine doc as canonical).