### PR TITLE
docs: update ECS version reference to 9.4.0

### DIFF
--- a/docs/rustinel-support.md
+++ b/docs/rustinel-support.md
@@ -274,7 +274,7 @@ flattens them and tags each line with its source set id for provenance.
 
 ## 7. Alert output
 
-Rustinel writes alerts as **ECS 9.3.0 NDJSON** to `logs/alerts.json.<date>`, which ingests cleanly
+Rustinel writes alerts as **ECS 9.4.0 NDJSON** to `logs/alerts.json.<date>`, which ingests cleanly
 into SIEM/log pipelines. Each Sigma/YARA/IOC match becomes one alert record carrying the rule/IOC
 identity, the matched event fields, and ATT&CK context where available.
 


### PR DESCRIPTION
## Summary

- Updates `docs/rustinel-support.md` to reference ECS 9.4.0, aligned with the schema bump in Karib0u/rustinel#38.