### PR TITLE
fix atomic CI compatibility with Rustinel 1.3

### DIFF
--- a/.github/workflows/atomic.yml
+++ b/.github/workflows/atomic.yml
@@ -159,6 +159,17 @@ jobs:
             --filter "${{ github.event.inputs.filter }}"
         shell: bash
 
+      # The engine runs as root on Unix and restricts its log directory to the
+      # owner. Hand ownership back to the runner after the engine exits so the
+      # artifact action can read the logs without weakening their permissions.
+      - name: Prepare engine logs for upload (Unix)
+        if: always() && matrix.platform != 'windows'
+        run: |
+          if [ -d tests/atomic/.engine/logs ]; then
+            sudo chown -R "$(id -u):$(id -g)" tests/atomic/.engine/logs
+          fi
+        shell: bash
+
       - name: Upload report + engine logs
         if: always()
         uses: actions/upload-artifact@v7

--- a/tests/atomic/atomics/windows/bcdedit_recovery_tamper.ps1
+++ b/tests/atomic/atomics/windows/bcdedit_recovery_tamper.ps1
@@ -8,6 +8,6 @@ $dir = Join-Path $env:TEMP 'rustinel-bcdedit-atomic'
 $bin = Join-Path $dir 'bcdedit.exe'
 New-Item -ItemType Directory -Path $dir -Force | Out-Null
 Copy-Item "$env:SystemRoot\System32\cmd.exe" $bin -Force
-& $bin /c echo recoveryenabled no | Out-Null
+& $bin /c echo recoveryenabled off | Out-Null
 Remove-Item $dir -Recurse -Force -ErrorAction SilentlyContinue
 exit 0


### PR DESCRIPTION
## Summary

- Transfer Unix engine-log ownership back to the runner after privileged atomic tests finish.
- Use `recoveryenabled off` in the Windows bcdedit fixture so it uniquely exercises the dedicated boot-recovery rule.

## Root cause

Rustinel 1.3 restricts Unix log directories and files to their owner. The Linux and macOS tests run the engine as root, so the artifact action could no longer read the logs.

Rustinel 1.3 also deterministically emits one highest-ranked Sigma match per event. The previous bcdedit fixture matched two equally severe rules, and the broader rule now wins the stable tie-break. The updated fixture exercises a condition unique to the dedicated rule.

## Validation

- `uv run python tools/validate.py`
- `uv run python tools/build_packs.py`
- `uv run python tests/atomic/run_atomics.py --check-coverage --strict-essential`
- `uv run ruff check tools`
- `uv run ruff format --check tools`
- `uv run ty check`
- `git diff --check`